### PR TITLE
【Fixed】デバッグツールを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,6 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  gem 'pry-rails'
-  gem 'better_errors'
   gem 'capistrano', '3.6.0'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -61,6 +59,9 @@ gem 'faker'
 group :development do
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'   # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 gem 'rails_admin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,6 +509,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,8 +4,8 @@ class BlogsController < ApplicationController
 
   def index
     @blogs = Blog.all
-    # binding.pry
-    # raise
+    #binding.pry
+    #raise
     respond_to do |format|
       format.html
       format.js

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,6 +4,8 @@ class BlogsController < ApplicationController
 
   def index
     @blogs = Blog.all
+    # binding.pry
+    raise
     respond_to do |format|
       format.html
       format.js

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -5,7 +5,7 @@ class BlogsController < ApplicationController
   def index
     @blogs = Blog.all
     # binding.pry
-    raise
+    # raise
     respond_to do |format|
       format.html
       format.js

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,5 +43,5 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener_web
   BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
 
-  
+
 end


### PR DESCRIPTION
#2 
・ Gemfileの記述を変更
gem 'pry-rails'
gem 'better_errors'が
group :development,  test do配下にあったため、
group :development do配下に移動させた。

・config/environments/development.rbの記述を変更
config.consider_all_requests_local の値をfalseからtrueに変更

・app/controllers/blogs_controller.rbの記述を変更
indexアクションのところに、binding_pryおよびraiseメソッドを挿入し、
デバッグツールが開発環境下で動くことを確認した。

